### PR TITLE
Removed python2.7 due to upcoming deprecation

### DIFF
--- a/14-InfrastructureAsCode (CloudFormation)/CustomResources/customresource.yaml
+++ b/14-InfrastructureAsCode (CloudFormation)/CustomResources/customresource.yaml
@@ -65,7 +65,7 @@ Resources:
     Properties:
       Description: Copies objects into buckets
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.8
       Role: !GetAtt S3CopyRole.Arn
       Timeout: 120
       Code:
@@ -107,7 +107,7 @@ Resources:
             for key in {x['Key'] for page in page_iterator for x in page['Contents']}:
               dest_key = os.path.join(prefix, os.path.relpath(key, source_prefix))
               if not key.endswith('/'):
-                print 'copy {} to {}'.format(key, dest_key)
+                print ('copy {} to {}'.format(key, dest_key))
                 client.copy_object(CopySource={'Bucket': source_bucket, 'Key': key}, Bucket=bucket, Key = dest_key)
             return cfnresponse.SUCCESS
 
@@ -117,7 +117,3 @@ Resources:
             objects = [{'Key': x['Key']} for page in page_iterator for x in page['Contents']]
             client.delete_objects(Bucket=bucket, Delete={'Objects': objects})
             return cfnresponse.SUCCESS
-
-
-
-


### PR DESCRIPTION
Deprecation notice: https://aws.amazon.com/blogs/compute/announcing-end-of-support-for-python-2-7-in-aws-lambda/

Added Python 3.8 support
Tested and confirmed stack creation/termination.